### PR TITLE
Fix issue where mset would be called on upper layers when lower layers return empty arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,11 +40,14 @@ export default class LayeredCache {
       pairs.push([keys[i], value])
     })
 
-    const tasks = this._layers
-    .slice(0, -1)
-    .map(layer => layer.mset(...pairs))
+    if (pairs.length !== 0) {
+      const tasks = this._layers
+        .slice(0, -1)
+        .map(layer => layer.mset(...pairs))
 
-    await Promise.all(tasks)
+      await Promise.all(tasks)
+    }
+
     return values
   }
 

--- a/test/layered-cache.js
+++ b/test/layered-cache.js
@@ -320,3 +320,23 @@ test('sync and msync', async t => {
   t.is(await cache.sync(1), 3, 'cache sync return value')
   t.deepEqual(await cache.msync(2, 3, 4), [4, 5, undefined], 'cache sync return value')
 })
+
+test('sync and msync returning all undefined does not call mset on upper layers', async t => {
+  const l = new LRU
+  const f = new FakeCache
+  const layers = [
+    l,
+    f
+  ]
+
+  let called = false
+  f.set(1, undefined)
+  f.set(2, undefined)
+  l.mset = () => {
+    called = true
+  }
+
+  const cache = new LCache(layers)
+  await cache.msync(1, 2)
+  t.is(called, false, 'mset was not called in upper layer')
+})


### PR DESCRIPTION
If all keys from an msync are undefined mset should not be called on upper layers as this forces client layer code to handle this case